### PR TITLE
Add wemake-python-styleguide

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ It could be anything from articles to books to videos that describes:
 - [PEP8](https://www.python.org/dev/peps/pep-0008/)
 - [Design Patterns Toptal Blog Post](https://www.toptal.com/python/python-design-patterns)
 - [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)
+- [wemake-python-styleguide](https://github.com/wemake-services/wemake-python-styleguide)
 
 ### Ruby
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ It could be anything from articles to books to videos that describes:
 - [PEP8](https://www.python.org/dev/peps/pep-0008/)
 - [Design Patterns Toptal Blog Post](https://www.toptal.com/python/python-design-patterns)
 - [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)
-- [wemake-python-styleguide](https://github.com/wemake-services/wemake-python-styleguide)
+- [wemake-python-styleguide (contains a list of stylistic rules / guidelines for Python code)](https://wemake-python-stylegui.de/en/latest/pages/usage/violations/index.html)
 
 ### Ruby
 


### PR DESCRIPTION
`wemake-python-styleguide` is the strictest linter in the python's ecosystem.
It also feature around 1000 automated rules of how to write idiomatic python code.
Including: complexity, naming standards, best practices, and enforcing pythonic ways of doing things.

It also has nice docs about all the rules and features inside: https://wemake-python-stylegui.de/en/latest/
Repo: https://github.com/wemake-services/wemake-python-styleguide